### PR TITLE
8주차 미션/ 2조 정현수

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/kuitandroidapiexample/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/home/screen/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -39,6 +40,7 @@ fun HomeScreen(
     padding: PaddingValues,
     navigateToRegister: () -> Unit = {},
     navigateToDetail: (Int) -> Unit = {},
+    navigateToPref:()->Unit={},
     viewModel: AnimalViewModel = viewModel()
 ) {
     val lazyState = rememberLazyListState()
@@ -98,6 +100,24 @@ fun HomeScreen(
                     .size(36.dp),
                 imageVector = Icons.Filled.Add,
                 contentDescription = "등록하기 버튼",
+                tint = colors.white
+            )
+        }
+
+        IconButton(
+            modifier = Modifier
+                .padding(start = 17.dp, bottom = 20.dp)
+                .size(56.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(colors.orange)
+                .align(Alignment.BottomStart),
+            onClick = navigateToPref
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(36.dp),
+                imageVector = Icons.Filled.Build,
+                contentDescription = "pref 버튼",
                 tint = colors.white
             )
         }

--- a/app/src/main/java/com/example/kuitandroidapiexample/home/screen/PreferencesScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/home/screen/PreferencesScreen.kt
@@ -2,7 +2,9 @@ package com.example.kuitandroidapiexample.home.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.TextField
 import androidx.compose.material3.Text
@@ -10,20 +12,75 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.kuitandroidapiexample.util.DataStoreManager
+import com.example.kuitandroidapiexample.util.SharedPreferenceManager
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 
 @Composable
 fun PreferencesScreen(modifier: Modifier = Modifier) {
 
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var input by remember { mutableStateOf("") }
     var result by remember { mutableStateOf("") }
 
+    //실습 부분
+    /* Column(
+         modifier = Modifier.fillMaxSize(),
+         horizontalAlignment = Alignment.CenterHorizontally,
+         verticalArrangement = Arrangement.Center
+     ) {
+         TextField(
+             value = input,
+             onValueChange = { input = it },
+             label = { Text("input value") }
+         )
+
+         Button(
+             onClick = {
+                 SharedPreferenceManager.saveValue(
+                     context = context,
+                     key = "sample_key",
+                     value = input
+                 )
+             }
+         ) {
+             Text("pref 저장")
+         }
+
+         Button(
+             onClick = {
+                 SharedPreferenceManager.deleteValue(context = context, key = "sample_key")
+             }
+         ) {
+             Text("pref 삭제")
+         }
+
+         Button(
+             onClick = {
+                 result =
+                     SharedPreferenceManager.getValue(context = context, key = "sample_key") ?: "없음"
+             }
+         ) {
+             Text("pref 조회")
+         }
+
+         Text("결과: $result")
+     }*/
+
+
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -33,29 +90,41 @@ fun PreferencesScreen(modifier: Modifier = Modifier) {
             label = { Text("input value") }
         )
 
-        Button(
-            onClick = {
+        Spacer(Modifier.height(8.dp))
 
+        Button(onClick = {
+            scope.launch {
+                DataStoreManager.saveValue(context, "sample_key", input)
             }
-        ) {
-            Text("pref 저장")
+        }) {
+            Text("DataStore 저장")
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        Button(onClick = {
+            scope.launch {
+                DataStoreManager.deleteValue(context, "sample_key")
+            }
+        }) {
+            Text("DataStore 삭제")
         }
 
         Button(
             onClick = {
-
+                scope.launch {
+                    result =
+                        DataStoreManager
+                            .getValue(context, "sample_key")
+                            .first()  // import kotlinx.coroutines.flow.first
+                            ?: "없음"
+                }
             }
         ) {
-            Text("pref 삭제")
+            Text("DataStore 조회")
         }
 
-        Button(
-            onClick = {
-
-            }
-        ) {
-            Text("pref 조회")
-        }
+        Spacer(Modifier.height(4.dp))
 
         Text("결과: $result")
     }

--- a/app/src/main/java/com/example/kuitandroidapiexample/home/screen/PreferencesScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/home/screen/PreferencesScreen.kt
@@ -1,0 +1,68 @@
+package com.example.kuitandroidapiexample.home.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.TextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+
+@Composable
+fun PreferencesScreen(modifier: Modifier = Modifier) {
+
+    var input by remember { mutableStateOf("") }
+    var result by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        TextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("input value") }
+        )
+
+        Button(
+            onClick = {
+
+            }
+        ) {
+            Text("pref 저장")
+        }
+
+        Button(
+            onClick = {
+
+            }
+        ) {
+            Text("pref 삭제")
+        }
+
+        Button(
+            onClick = {
+
+            }
+        ) {
+            Text("pref 조회")
+        }
+
+        Text("결과: $result")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreferencesScreenPreview() {
+    PreferencesScreen()
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/navigation/MainNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.kuitandroidapiexample.detail.screen.DetailScreen
 import com.example.kuitandroidapiexample.home.screen.HomeScreen
+import com.example.kuitandroidapiexample.home.screen.PreferencesScreen
 import com.example.kuitandroidapiexample.register.screen.RegisterScreen
 
 @Composable
@@ -26,7 +27,8 @@ fun MainNavHost(
                 navigateToRegister = { navController.navigate(Route.Register) },
                 navigateToDetail = { index ->
                     navController.navigate(Route.Detail(index))
-                }
+                },
+                navigateToPref = {navController.navigate(Route.Preference)}
             )
         }
         composable<Route.Register> {
@@ -44,6 +46,9 @@ fun MainNavHost(
                 index = args.index,
                 navigateToBack = { navController.navigateUp() }
             )
+        }
+        composable<Route.Preference>{
+            PreferencesScreen()
         }
     }
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/navigation/Route.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/navigation/Route.kt
@@ -11,4 +11,7 @@ sealed interface Route {
 
     @Serializable
     data class Detail(val index: Int) : Route
+
+    @Serializable
+    data object Preference : Route
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/DataStore/DataStoreExtensions.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/DataStore/DataStoreExtensions.kt
@@ -1,0 +1,9 @@
+package com.example.kuitandroidapiexample.util.DataStore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.Preferences
+
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "my_prefs")

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/DataStore/DataStoreManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/DataStore/DataStoreManager.kt
@@ -1,0 +1,33 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.example.kuitandroidapiexample.util.DataStore.dataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+object DataStoreManager {
+    // 동적 키 생성
+    private fun keyOf(name: String) = stringPreferencesKey(name)
+
+    // 저장 (suspend)
+    suspend fun saveValue(context: Context, key: String, value: String) {
+        context.dataStore.edit { prefs ->
+            prefs[keyOf(key)] = value
+        }
+    }
+
+    // 읽기 (Flow)
+    fun getValue(context: Context, key: String): Flow<String?> =
+        context.dataStore.data
+            .map { prefs -> prefs[keyOf(key)] }
+
+    // 삭제 (suspend)
+    suspend fun deleteValue(context: Context, key: String) {
+        context.dataStore.edit { prefs ->
+            prefs.remove(keyOf(key))
+        }
+    }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
@@ -1,0 +1,27 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import android.system.Os.remove
+import androidx.compose.runtime.key
+import androidx.core.content.edit
+import coil3.memory.MemoryCache
+
+object SharedPreferenceManager {
+    fun saveValue(context: Context, key: String, value: String) {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit {
+            putString(key, value)
+        }
+    }
+
+    fun getValue(context: Context, key: String): String? {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        return prefs.getString(key, null)
+    }
+
+
+    fun deleteValue(context: Context, key: String) {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit{ remove(key) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ okhttp = "4.11.0"
 retrofit = "2.9.0"
 retrofitKotlinSerializationConverter = "1.0.0"
 kotlinxSerializationJson = "1.6.3"
+datastorePreferences = "1.2.0-alpha02"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,6 +37,7 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinSerializationConverter" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- 실습에 나온 SharedPreferencesManager 사용
    - [x]  실습 내용 구현해오기
- DataStoreManager 완성
    - [x]  실습에서 작성한 PreferencesScreen에 기존의 SharedPreferencesManager 대신 DataStoreManager를 사용한 코드로 변경해오기 (두 경우 모두 시연할 수 있도록 기존의 코드는 주석처리해두기)
    
    
![스크린샷 2025-05-18 192910](https://github.com/user-attachments/assets/f285bf9b-4710-4f25-9ae0-240dbc6c4532)
![스크린샷 2025-05-18 192900](https://github.com/user-attachments/assets/05743a8f-c944-4e5a-a4d4-b3c748a7704a)
![스크린샷 2025-05-18 192838](https://github.com/user-attachments/assets/7f077e23-b454-43ab-a865-fd9d17ca0e32)
![스크린샷 2025-05-18 192918](https://github.com/user-attachments/assets/47a87f98-d41d-4beb-a5c1-aa097385ed6a)
![스크린샷 2025-05-18 192956](https://github.com/user-attachments/assets/e56dda62-8e02-434e-8f03-556a51c63fbe)
