### PR TITLE
8주차 미션 / 2조 고현규

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/kuitandroidapiexample/App.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/App.kt
@@ -1,0 +1,7 @@
+package com.example.kuitandroidapiexample
+
+import android.app.Application
+
+class App: Application() {
+    val appContainer by lazy { AppContainer() }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/AppContainer.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/AppContainer.kt
@@ -5,7 +5,9 @@ import com.example.kuitandroidapiexample.data.repository.AnimalRepository
 
 class AppContainer {
     private fun provideApiService() = animalService
-    fun provideAnimalRepository(): AnimalRepository {
-        return AnimalRepository(provideApiService())
-    }
+//    fun provideAnimalRepository(): AnimalRepository {
+//        //return AnimalRepository(provideApiService())
+//        return AnimalRepository(animalService)
+//    }
+    fun provideAnimalRepository() = AnimalRepository(provideApiService())
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/AppContainer.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/AppContainer.kt
@@ -1,0 +1,11 @@
+package com.example.kuitandroidapiexample
+
+import com.example.kuitandroidapiexample.data.ServicePool.animalService
+import com.example.kuitandroidapiexample.data.repository.AnimalRepository
+
+class AppContainer {
+    private fun provideApiService() = animalService
+    fun provideAnimalRepository(): AnimalRepository {
+        return AnimalRepository(provideApiService())
+    }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/MainActivity.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import com.example.kuitandroidapiexample.navigation.MainNavHost
+import com.example.kuitandroidapiexample.ui.navigation.MainNavHost
 import com.example.kuitandroidapiexample.ui.theme.KuitAndroidApiExampleTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/kuitandroidapiexample/data/dto/request/RequestAddAnimalDto.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/data/dto/request/RequestAddAnimalDto.kt
@@ -1,6 +1,6 @@
 package com.example.kuitandroidapiexample.data.dto.request
 
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/app/src/main/java/com/example/kuitandroidapiexample/data/dto/response/ResponseAnimalDetailDto.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/data/dto/response/ResponseAnimalDetailDto.kt
@@ -1,6 +1,6 @@
 package com.example.kuitandroidapiexample.data.dto.response
 
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/data/dto/response/ResponseAnimalDto.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/data/dto/response/ResponseAnimalDto.kt
@@ -1,6 +1,6 @@
 package com.example.kuitandroidapiexample.data.dto.response
 
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/data/repository/AnimalRepository.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/data/repository/AnimalRepository.kt
@@ -1,0 +1,36 @@
+package com.example.kuitandroidapiexample.data.repository
+
+import com.example.kuitandroidapiexample.data.dto.request.RequestAddAnimalDto
+import com.example.kuitandroidapiexample.data.dto.response.BaseResponse
+import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDetailDto
+import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDto
+import com.example.kuitandroidapiexample.data.dto.response.ResponseDeleteAnimalDto
+import com.example.kuitandroidapiexample.data.service.AnimalService
+
+class AnimalRepository(
+    private val service: AnimalService
+) {
+    suspend fun getTotalAnimalList(): Result<BaseResponse<List<ResponseAnimalDto>>> {
+        return runCatching {
+            service.getTotalAnimalList()
+        }
+    }
+
+    suspend fun getAnimalDetail(id: Int): Result<BaseResponse<ResponseAnimalDetailDto>> {
+        return runCatching {
+            service.getAnimalDetail(id)
+        }
+    }
+
+    suspend fun postAddAnimal(request: RequestAddAnimalDto): Result<Unit> {
+        return runCatching {
+            service.postAddAnimal(request)
+        }
+    }
+
+    suspend fun deleteAnimal(id: Int): Result<ResponseDeleteAnimalDto> {
+        return runCatching {
+            service.deleteAnimal(id)
+        }
+    }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/data/repository/AnimalRepository.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/data/repository/AnimalRepository.kt
@@ -8,29 +8,30 @@ import com.example.kuitandroidapiexample.data.dto.response.ResponseDeleteAnimalD
 import com.example.kuitandroidapiexample.data.service.AnimalService
 
 class AnimalRepository(
-    private val service: AnimalService
+    private val animalService: AnimalService
 ) {
     suspend fun getTotalAnimalList(): Result<BaseResponse<List<ResponseAnimalDto>>> {
         return runCatching {
-            service.getTotalAnimalList()
+            animalService.getTotalAnimalList()
         }
     }
 
     suspend fun getAnimalDetail(id: Int): Result<BaseResponse<ResponseAnimalDetailDto>> {
         return runCatching {
-            service.getAnimalDetail(id)
+            animalService.getAnimalDetail(id)
         }
     }
+    //suspend fun getAnimalDetail(id: Int) = runCatching { animalService.getAnimalDetail(id) }
 
     suspend fun postAddAnimal(request: RequestAddAnimalDto): Result<Unit> {
         return runCatching {
-            service.postAddAnimal(request)
+            animalService.postAddAnimal(request)
         }
     }
 
     suspend fun deleteAnimal(id: Int): Result<ResponseDeleteAnimalDto> {
         return runCatching {
-            service.deleteAnimal(id)
+            animalService.deleteAnimal(id)
         }
     }
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/common/TagChip.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/common/TagChip.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.common
+package com.example.kuitandroidapiexample.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/screen/DetailScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/screen/DetailScreen.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.detail.screen
+package com.example.kuitandroidapiexample.ui.detail.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -32,9 +32,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.example.kuitandroidapiexample.R
-import com.example.kuitandroidapiexample.common.TagChip
-import com.example.kuitandroidapiexample.home.viewmodel.AnimalViewModel
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.common.TagChip
+import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/screen/DetailScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/screen/DetailScreen.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.example.kuitandroidapiexample.R
 import com.example.kuitandroidapiexample.ui.common.TagChip
+import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModel
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
@@ -43,19 +45,17 @@ fun DetailScreen(
     padding: PaddingValues,
     index: Int,
     navigateToBack: () -> Unit = {},
-    viewModel: AnimalViewModel = viewModel()
+    viewModel: AnimalDetailViewModel = viewModel()
 ) {
-    val response by viewModel.animalDetailState
-    val animalDetail = response
 
-    val deleteAnimal by viewModel.deleteAnimalState
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(index) {
         viewModel.getAnimalDetail(index)
     }
 
-    LaunchedEffect(deleteAnimal) {
-        if (deleteAnimal == true) {
+    LaunchedEffect(uiState.isDelete) {
+        if (uiState.isDelete) {
             navigateToBack()
         }
     }
@@ -84,7 +84,7 @@ fun DetailScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(420.dp),
-                model = animalDetail?.url ?: "",
+                model = uiState.url,
                 contentDescription = "동물 사진"
             )
         }
@@ -97,14 +97,14 @@ fun DetailScreen(
                 .clip(RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp))
         ) {
             Text(
-                text = animalDetail?.name ?: "",
+                text = uiState.reporterName,
                 style = typography.semiBold.copy(fontSize = 24.sp),
                 modifier = Modifier.padding(start = 40.dp, top = 42.dp, bottom = 20.dp)
             )
 
             TagChip(
                 modifier = Modifier.padding(start = 40.dp),
-                animalType = animalDetail?.state ?: AnimalType.PROTECT
+                animalType = uiState.animalType
             )
             Spacer(modifier = Modifier.height(30.dp))
 
@@ -127,7 +127,7 @@ fun DetailScreen(
                     style = typography.semiBold.copy(fontSize = 14.sp, color = colors.orange),
                 )
                 Text(
-                    text = animalDetail?.address ?: "",
+                    text = uiState.address,
                     style = typography.semiBold.copy(fontSize = 14.sp),
                     modifier = Modifier.align(Alignment.BottomStart)
                 )

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/AnimalDetailUiState.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/AnimalDetailUiState.kt
@@ -8,4 +8,5 @@ data class AnimalDetailUiState(
     val animalType: AnimalType = AnimalType.PROTECT,
     val address: String = "",
     val reporterName: String = "",
+    val isDelete: Boolean = false,
 )

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/AnimalDetailUiState.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/AnimalDetailUiState.kt
@@ -1,0 +1,11 @@
+package com.example.kuitandroidapiexample.ui.detail.uistate
+
+import com.example.kuitandroidapiexample.ui.model.AnimalType
+
+data class AnimalDetailUiState(
+    val url: String = "",
+    val animalName: String = "",
+    val animalType: AnimalType = AnimalType.PROTECT,
+    val address: String = "",
+    val reporterName: String = "",
+)

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/ResponseAnimalDataDtoMapper.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/uistate/ResponseAnimalDataDtoMapper.kt
@@ -1,0 +1,11 @@
+package com.example.kuitandroidapiexample.ui.detail.uistate
+
+import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDetailDto
+
+fun ResponseAnimalDetailDto.toUiState() = AnimalDetailUiState(
+    url = this.url,
+    animalName = this.breed,
+    animalType = this.state,
+    address = this.address,
+    reporterName = this.name
+)

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/viewmodel/AnimalDetailViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/viewmodel/AnimalDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.kuitandroidapiexample.ui.detail.viewmodel
 
-import android.R.attr.data
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -10,11 +9,12 @@ import com.example.kuitandroidapiexample.ui.detail.uistate.AnimalDetailUiState
 import com.example.kuitandroidapiexample.ui.detail.uistate.toUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AnimalDetailViewModel(
     private val animalRepository: AnimalRepository
-): ViewModel() {
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AnimalDetailUiState())
     val uiState = _uiState.asStateFlow()
@@ -29,6 +29,30 @@ class AnimalDetailViewModel(
                     Log.e("okhttpError", error.message.toString())
                 }
             )
+        }
+    }
+
+    fun deleteAnimal(id: Int) {
+        viewModelScope.launch {
+            animalRepository.deleteAnimal(id).fold(
+                onSuccess = {
+                    _uiState.update { it.copy(isDelete = true) }
+                },
+                onFailure = { error ->
+                    Log.e("deleteAnimalError", error.message.toString())
+                }
+            )
+//            runCatching {
+//                //animalService.deleteAnimal(id)
+//                repository.deleteAnimal(id)
+//            }.fold(
+//                onSuccess = { response ->
+//                    Log.d("deleteAnimal", "삭제 성공. ID: ${id}, message: ${response.toString()}")
+//                },
+//                onFailure = { error ->
+//                    Log.e("deleteAnimal", error.message ?: "Unknown error")
+//                }
+//            )
         }
     }
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/viewmodel/AnimalDetailViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/detail/viewmodel/AnimalDetailViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.kuitandroidapiexample.ui.detail.viewmodel
+
+import android.R.attr.data
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.kuitandroidapiexample.data.repository.AnimalRepository
+import com.example.kuitandroidapiexample.ui.detail.uistate.AnimalDetailUiState
+import com.example.kuitandroidapiexample.ui.detail.uistate.toUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class AnimalDetailViewModel(
+    private val animalRepository: AnimalRepository
+): ViewModel() {
+
+    private val _uiState = MutableStateFlow(AnimalDetailUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun getAnimalDetail(id: Int) {
+        viewModelScope.launch {
+            animalRepository.getAnimalDetail(id).fold(
+                onSuccess = { data ->
+                    _uiState.value = data.data.toUiState()
+                },
+                onFailure = { error ->
+                    Log.e("okhttpError", error.message.toString())
+                }
+            )
+        }
+    }
+
+}
+
+class AnimalDetailViewModelFactory(
+    private val animalRepository: AnimalRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AnimalDetailViewModel(animalRepository) as T
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/component/AnimalItem.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/component/AnimalItem.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.home.component
+package com.example.kuitandroidapiexample.ui.home.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,9 +21,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.example.kuitandroidapiexample.R
-import com.example.kuitandroidapiexample.common.TagChip
+import com.example.kuitandroidapiexample.ui.common.TagChip
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDto
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.home.screen
+package com.example.kuitandroidapiexample.ui.home.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -29,8 +29,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.kuitandroidapiexample.home.component.AnimalItem
-import com.example.kuitandroidapiexample.home.viewmodel.AnimalViewModel
+import com.example.kuitandroidapiexample.ui.home.component.AnimalItem
+import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -39,6 +40,7 @@ fun HomeScreen(
     padding: PaddingValues,
     navigateToRegister: () -> Unit = {},
     navigateToDetail: (Int) -> Unit = {},
+    navigateToPref: () -> Unit = {},
     viewModel: AnimalViewModel = viewModel()
 ) {
     val lazyState = rememberLazyListState()
@@ -98,6 +100,23 @@ fun HomeScreen(
                     .size(36.dp),
                 imageVector = Icons.Filled.Add,
                 contentDescription = "등록하기 버튼",
+                tint = colors.white
+            )
+        }
+        IconButton(
+            modifier = Modifier
+                .padding(start = 17.dp, bottom = 20.dp)
+                .size(56.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(colors.orange)
+                .align(Alignment.BottomStart),
+            onClick = navigateToPref
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(36.dp),
+                imageVector = Icons.Filled.Build,
+                contentDescription = "pref 버튼",
                 tint = colors.white
             )
         }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/PreferencesScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/PreferencesScreen.kt
@@ -1,0 +1,82 @@
+package com.example.kuitandroidapiexample.ui.home.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.kuitandroidapiexample.util.DataStoreManager
+import kotlinx.coroutines.launch
+
+@Composable
+fun PreferencesScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var input by remember { mutableStateOf("") }
+    var result by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        TextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("input value") }
+        )
+
+        Button(
+            onClick = {
+                //SharedPreferenceManager.saveValue(context = context, key = "sample_key", value = input)
+                scope.launch {
+                    DataStoreManager.saveValue(context, input)
+                }
+            }
+        ) {
+            Text("pref 저장")
+        }
+        Button(
+            onClick = {
+                //SharedPreferenceManager.deleteValue(context = context, key = "sample_key")
+                scope.launch {
+                    DataStoreManager.deleteValue(context)
+                }
+            }
+        ) {
+            Text("pref 삭제")
+        }
+        Button(
+            onClick = {
+                //result = SharedPreferenceManager.getValue(context = context, key = "sample_key") ?: "없음"
+                scope.launch {
+                    DataStoreManager.getValue(context).collect {
+                        result = it ?: "없음"
+                    }
+                }
+            }
+        ) {
+            Text("pref 조회")
+        }
+
+        Text("결과 : $result")
+    }
+}
+
+@Preview
+@Composable
+private fun PreferencesScreenPreview() {
+    PreferencesScreen()
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.home.viewmodel
+package com.example.kuitandroidapiexample.ui.home.viewmodel
 
 import android.util.Log
 import androidx.compose.runtime.State

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
@@ -12,12 +12,14 @@ import com.example.kuitandroidapiexample.data.dto.request.RequestAddAnimalDto
 import com.example.kuitandroidapiexample.data.dto.response.BaseResponse
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDetailDto
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDto
+import com.example.kuitandroidapiexample.data.repository.AnimalRepository
 import com.example.kuitandroidapiexample.data.service.AnimalService
 import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.coroutines.launch
 
 class AnimalViewModel(
-    private val animalService: AnimalService
+    //private val animalService: AnimalService
+    private val repository: AnimalRepository
 ) : ViewModel() {
     //private val animalService: AnimalService by lazy { ServicePool.animalService }
 
@@ -36,9 +38,10 @@ class AnimalViewModel(
     fun getTotalAnimalList() {
         viewModelScope.launch {
             runCatching {
-                animalService.getTotalAnimalList()
+                //animalService.getTotalAnimalList()
+                repository.getTotalAnimalList()
             }.onSuccess { data ->
-                _animalListState.value = data
+                _animalListState.value = data.getOrNull()
             }.onFailure { error ->
                 Log.e("getTotalAnimalList", error.message ?: "Unknown error")
             }
@@ -48,10 +51,11 @@ class AnimalViewModel(
     fun getAnimalDetail(id: Int) {
         viewModelScope.launch {
             runCatching {
-                animalService.getAnimalDetail(id)
+                //animalService.getAnimalDetail(id)
+                repository.getAnimalDetail(id)
             }.fold(
                 onSuccess = { data ->
-                    _animalDetailState.value = data.data
+                    _animalDetailState.value = data.getOrNull()?.data
                 },
                 onFailure = { error ->
                     Log.e("getAnimalDetail", error.message ?: "Unknown error")
@@ -63,7 +67,8 @@ class AnimalViewModel(
     fun postAddAnimal(request: RequestAddAnimalDto) {
         viewModelScope.launch {
             runCatching {
-                animalService.postAddAnimal(request)
+                //animalService.postAddAnimal(request)
+                repository.postAddAnimal(request)
             }.fold(
                 onSuccess = {
                     Log.d("postAddAnimal", "등록 성공")
@@ -80,10 +85,11 @@ class AnimalViewModel(
     fun deleteAnimal(id: Int) {
         viewModelScope.launch {
             runCatching {
-                animalService.deleteAnimal(id)
+                //animalService.deleteAnimal(id)
+                repository.deleteAnimal(id)
             }.fold(
                 onSuccess = { response ->
-                    Log.d("deleteAnimal", "삭제 성공. ID: ${response.data.id}, message: ${response.message}")
+                    Log.d("deleteAnimal", "삭제 성공. ID: ${id}, message: ${response.toString()}")
                 },
                 onFailure = { error ->
                     Log.e("deleteAnimal", error.message ?: "Unknown error")
@@ -111,9 +117,14 @@ class AnimalViewModel(
     }
 }
 
+//class AnimalViewModelFactory(
+//    private val animalService: AnimalService
+//): ViewModelProvider.Factory{
+//    override fun <T : ViewModel> create(modelClass: Class<T>): T = AnimalViewModel(animalService) as T
+//}
 class AnimalViewModelFactory(
-    private val animalService: AnimalService
-): ViewModelProvider.Factory{
-    override fun <T : ViewModel> create(modelClass: Class<T>): T = AnimalViewModel(animalService) as T
-
+    private val animalRepository: AnimalRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AnimalViewModel(animalRepository) as T
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
@@ -6,39 +6,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.example.kuitandroidapiexample.data.ServicePool
-import com.example.kuitandroidapiexample.data.ServicePool.animalService
 import com.example.kuitandroidapiexample.data.dto.request.RequestAddAnimalDto
 import com.example.kuitandroidapiexample.data.dto.response.BaseResponse
-import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDetailDto
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDto
 import com.example.kuitandroidapiexample.data.repository.AnimalRepository
-import com.example.kuitandroidapiexample.data.service.AnimalService
 import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.coroutines.launch
 
 class AnimalViewModel(
-    //private val animalService: AnimalService
     private val repository: AnimalRepository
 ) : ViewModel() {
-    //private val animalService: AnimalService by lazy { ServicePool.animalService }
 
     private val _animalListState = mutableStateOf<BaseResponse<List<ResponseAnimalDto>>?>(null)
     val animalListState: State<BaseResponse<List<ResponseAnimalDto>>?> get() = _animalListState
 
-    private val _animalDetailState = mutableStateOf<ResponseAnimalDetailDto?>(null)
-    val animalDetailState: State<ResponseAnimalDetailDto?> get() = _animalDetailState
-
-    private val _addAnimalState = mutableStateOf<Boolean?>(null)
-    val addAnimalState: State<Boolean?> get() = _addAnimalState
-
-    private val _deleteAnimalState = mutableStateOf<Boolean?>(null)
-    val deleteAnimalState: State<Boolean?> get() = _deleteAnimalState
-
     fun getTotalAnimalList() {
         viewModelScope.launch {
             runCatching {
-                //animalService.getTotalAnimalList()
                 repository.getTotalAnimalList()
             }.onSuccess { data ->
                 _animalListState.value = data.getOrNull()
@@ -48,80 +32,8 @@ class AnimalViewModel(
         }
     }
 
-    fun getAnimalDetail(id: Int) {
-        viewModelScope.launch {
-            runCatching {
-                //animalService.getAnimalDetail(id)
-                repository.getAnimalDetail(id)
-            }.fold(
-                onSuccess = { data ->
-                    _animalDetailState.value = data.getOrNull()?.data
-                },
-                onFailure = { error ->
-                    Log.e("getAnimalDetail", error.message ?: "Unknown error")
-                }
-            )
-        }
-    }
-
-    fun postAddAnimal(request: RequestAddAnimalDto) {
-        viewModelScope.launch {
-            runCatching {
-                //animalService.postAddAnimal(request)
-                repository.postAddAnimal(request)
-            }.fold(
-                onSuccess = {
-                    Log.d("postAddAnimal", "등록 성공")
-                    _addAnimalState.value = true
-                },
-                onFailure = { error ->
-                    Log.e("postAddAnimal", error.message ?: "Unknown error")
-                    _addAnimalState.value = false
-                }
-            )
-        }
-    }
-
-    fun deleteAnimal(id: Int) {
-        viewModelScope.launch {
-            runCatching {
-                //animalService.deleteAnimal(id)
-                repository.deleteAnimal(id)
-            }.fold(
-                onSuccess = { response ->
-                    Log.d("deleteAnimal", "삭제 성공. ID: ${id}, message: ${response.toString()}")
-                },
-                onFailure = { error ->
-                    Log.e("deleteAnimal", error.message ?: "Unknown error")
-                }
-            )
-        }
-    }
-
-    fun addAnimal(
-        url: String,
-        name: String,
-        state: AnimalType,
-        breed: String,
-        address: String
-    ) {
-        val request = RequestAddAnimalDto(
-            id = 1,
-            url = url,
-            name = name,
-            state = state,
-            breed = breed,
-            address = address
-        )
-        postAddAnimal(request)
-    }
 }
 
-//class AnimalViewModelFactory(
-//    private val animalService: AnimalService
-//): ViewModelProvider.Factory{
-//    override fun <T : ViewModel> create(modelClass: Class<T>): T = AnimalViewModel(animalService) as T
-//}
 class AnimalViewModelFactory(
     private val animalRepository: AnimalRepository
 ) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/viewmodel/AnimalViewModel.kt
@@ -4,18 +4,22 @@ import android.util.Log
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.kuitandroidapiexample.data.ServicePool
+import com.example.kuitandroidapiexample.data.ServicePool.animalService
 import com.example.kuitandroidapiexample.data.dto.request.RequestAddAnimalDto
 import com.example.kuitandroidapiexample.data.dto.response.BaseResponse
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDetailDto
 import com.example.kuitandroidapiexample.data.dto.response.ResponseAnimalDto
 import com.example.kuitandroidapiexample.data.service.AnimalService
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import kotlinx.coroutines.launch
 
-class AnimalViewModel : ViewModel() {
-    private val animalService: AnimalService by lazy { ServicePool.animalService }
+class AnimalViewModel(
+    private val animalService: AnimalService
+) : ViewModel() {
+    //private val animalService: AnimalService by lazy { ServicePool.animalService }
 
     private val _animalListState = mutableStateOf<BaseResponse<List<ResponseAnimalDto>>?>(null)
     val animalListState: State<BaseResponse<List<ResponseAnimalDto>>?> get() = _animalListState
@@ -105,4 +109,11 @@ class AnimalViewModel : ViewModel() {
         )
         postAddAnimal(request)
     }
+}
+
+class AnimalViewModelFactory(
+    private val animalService: AnimalService
+): ViewModelProvider.Factory{
+    override fun <T : ViewModel> create(modelClass: Class<T>): T = AnimalViewModel(animalService) as T
+
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/model/AnimalData.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/model/AnimalData.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.model
+package com.example.kuitandroidapiexample.ui.model
 
 data class AnimalData(
     val imageUrl: String,

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/model/AnimalType.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/model/AnimalType.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.model
+package com.example.kuitandroidapiexample.ui.model
 
 enum class AnimalType(
     val type: String

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
@@ -2,12 +2,17 @@ package com.example.kuitandroidapiexample.ui.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.example.kuitandroidapiexample.App
 import com.example.kuitandroidapiexample.ui.detail.screen.DetailScreen
 import com.example.kuitandroidapiexample.ui.home.screen.HomeScreen
+import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
+import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModelFactory
 import com.example.kuitandroidapiexample.ui.register.screen.RegisterScreen
 
 @Composable
@@ -15,6 +20,14 @@ fun MainNavHost(
     padding: PaddingValues
 ) {
     val navController = rememberNavController()
+
+    val context = LocalContext.current.applicationContext as App
+//    val viewModel: AnimalViewModel = viewModel(
+//        factory = AnimalViewModelFactory(context.appContainer.provideApiService())
+//    )
+    val viewModel: AnimalViewModel = viewModel(
+        factory = AnimalViewModelFactory(context.appContainer.provideAnimalRepository())
+    )
 
     NavHost(
         navController = navController,
@@ -26,14 +39,15 @@ fun MainNavHost(
                 navigateToRegister = { navController.navigate(Route.Register) },
                 navigateToDetail = { index ->
                     navController.navigate(Route.Detail(index))
-                }
+                },
+                viewModel = viewModel
             )
         }
         composable<Route.Register> {
             RegisterScreen(
                 padding = padding,
-                navigateToBack = { navController.navigateUp() }
-
+                navigateToBack = { navController.navigateUp() },
+                viewModel = viewModel
             )
         }
         composable<Route.Detail> { navBackStackEntry ->
@@ -42,7 +56,8 @@ fun MainNavHost(
             DetailScreen(
                 padding = padding,
                 index = args.index,
-                navigateToBack = { navController.navigateUp() }
+                navigateToBack = { navController.navigateUp() },
+                viewModel = viewModel
             )
         }
     }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
@@ -13,6 +13,7 @@ import com.example.kuitandroidapiexample.ui.detail.screen.DetailScreen
 import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModel
 import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModelFactory
 import com.example.kuitandroidapiexample.ui.home.screen.HomeScreen
+import com.example.kuitandroidapiexample.ui.home.screen.PreferencesScreen
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModelFactory
 import com.example.kuitandroidapiexample.ui.register.screen.RegisterScreen
@@ -50,6 +51,7 @@ fun MainNavHost(
                 navigateToDetail = { index ->
                     navController.navigate(Route.Detail(index))
                 },
+                navigateToPref = { navController.navigate(Route.Preference) },
                 viewModel = viewModel
             )
         }
@@ -69,6 +71,9 @@ fun MainNavHost(
                 navigateToBack = { navController.navigateUp() },
                 viewModel = detailViewModel
             )
+        }
+        composable<Route.Preference> {
+            PreferencesScreen()
         }
     }
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.navigation
+package com.example.kuitandroidapiexample.ui.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
@@ -6,9 +6,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import com.example.kuitandroidapiexample.detail.screen.DetailScreen
-import com.example.kuitandroidapiexample.home.screen.HomeScreen
-import com.example.kuitandroidapiexample.register.screen.RegisterScreen
+import com.example.kuitandroidapiexample.ui.detail.screen.DetailScreen
+import com.example.kuitandroidapiexample.ui.home.screen.HomeScreen
+import com.example.kuitandroidapiexample.ui.register.screen.RegisterScreen
 
 @Composable
 fun MainNavHost(

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
@@ -10,10 +10,14 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.kuitandroidapiexample.App
 import com.example.kuitandroidapiexample.ui.detail.screen.DetailScreen
+import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModel
+import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModelFactory
 import com.example.kuitandroidapiexample.ui.home.screen.HomeScreen
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModelFactory
 import com.example.kuitandroidapiexample.ui.register.screen.RegisterScreen
+import com.example.kuitandroidapiexample.ui.register.viewmodel.AnimalRegisterViewModel
+import com.example.kuitandroidapiexample.ui.register.viewmodel.AnimalRegisterViewModelFactory
 
 @Composable
 fun MainNavHost(
@@ -27,6 +31,12 @@ fun MainNavHost(
 //    )
     val viewModel: AnimalViewModel = viewModel(
         factory = AnimalViewModelFactory(context.appContainer.provideAnimalRepository())
+    )
+    val detailViewModel: AnimalDetailViewModel = viewModel(
+        factory = AnimalDetailViewModelFactory(context.appContainer.provideAnimalRepository())
+    )
+    val registerViewModel: AnimalRegisterViewModel = viewModel(
+        factory = AnimalRegisterViewModelFactory(context.appContainer.provideAnimalRepository())
     )
 
     NavHost(
@@ -47,7 +57,7 @@ fun MainNavHost(
             RegisterScreen(
                 padding = padding,
                 navigateToBack = { navController.navigateUp() },
-                viewModel = viewModel
+                viewModel = registerViewModel
             )
         }
         composable<Route.Detail> { navBackStackEntry ->
@@ -57,7 +67,7 @@ fun MainNavHost(
                 padding = padding,
                 index = args.index,
                 navigateToBack = { navController.navigateUp() },
-                viewModel = viewModel
+                viewModel = detailViewModel
             )
         }
     }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.navigation
+package com.example.kuitandroidapiexample.ui.navigation
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
@@ -11,4 +11,7 @@ sealed interface Route {
 
     @Serializable
     data class Detail(val index: Int) : Route
+
+    @Serializable
+    data object Preference : Route
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/addstate/AnimalRegisterAddState.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/addstate/AnimalRegisterAddState.kt
@@ -1,0 +1,7 @@
+package com.example.kuitandroidapiexample.ui.register.addstate
+
+import com.example.kuitandroidapiexample.ui.register.model.AddAnimalStateType
+
+data class AnimalRegisterAddState(
+    val addState: AddAnimalStateType = AddAnimalStateType.PENDING,
+)

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/componet/FindUTextField.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/componet/FindUTextField.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.register.componet
+package com.example.kuitandroidapiexample.ui.register.componet
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/componet/TypeSelectContent.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/componet/TypeSelectContent.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.register.componet
+package com.example.kuitandroidapiexample.ui.register.componet
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.kuitandroidapiexample.model.AnimalType
+import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 
 @Composable

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/model/AddAnimalStateType.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/model/AddAnimalStateType.kt
@@ -1,0 +1,9 @@
+package com.example.kuitandroidapiexample.ui.register.model
+
+enum class AddAnimalStateType(
+    val addState: String
+) {
+    PENDING("등록중"),
+    ADDSUCCESS("등록성공"),
+    ADDFAILURE("등록실패")
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/screen/RegisterScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/screen/RegisterScreen.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.model.AnimalType
 import com.example.kuitandroidapiexample.ui.register.componet.FindUTextField
 import com.example.kuitandroidapiexample.ui.register.componet.TypeSelectContent
+import com.example.kuitandroidapiexample.ui.register.model.AddAnimalStateType
+import com.example.kuitandroidapiexample.ui.register.viewmodel.AnimalRegisterViewModel
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 import kotlinx.coroutines.launch
@@ -43,7 +45,7 @@ import kotlinx.coroutines.launch
 fun RegisterScreen(
     padding: PaddingValues,
     navigateToBack: () -> Unit = {},
-    viewModel: AnimalViewModel = viewModel()
+    viewModel: AnimalRegisterViewModel = viewModel()
 ) {
     var url by remember { mutableStateOf("") }
     var animalName by remember { mutableStateOf("") }
@@ -51,32 +53,35 @@ fun RegisterScreen(
     var reporterName by remember { mutableStateOf("") }
     var animalType by remember { mutableStateOf(AnimalType.PROTECT) }
 
-    val addAnimal by viewModel.addAnimalState
+    val addAnimal by viewModel.addState.collectAsStateWithLifecycle()
 
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(addAnimal) {
-        if (addAnimal == true) {
+    LaunchedEffect(addAnimal.addState) {
+        if (addAnimal.addState == AddAnimalStateType.ADDSUCCESS) {
             scope.launch {
                 val result = snackbarHostState.showSnackbar(
                     message = "등록 완료",
                     duration = SnackbarDuration.Short,
                     withDismissAction = true
                 )
-                if (result == SnackbarResult.Dismissed)
+                if (result == SnackbarResult.Dismissed) {
+                    viewModel.resetAddState()
                     navigateToBack()
+                }
             }
-            //navigateToBack()
-        }else if(addAnimal == false){
+        }else if(addAnimal.addState == AddAnimalStateType.ADDFAILURE){
             scope.launch {
                 val result = snackbarHostState.showSnackbar(
                     message = "등록 실패",
                     duration = SnackbarDuration.Short,
                     withDismissAction = true
                 )
-                if (result == SnackbarResult.Dismissed)
+                if (result == SnackbarResult.Dismissed) {
+                    viewModel.resetAddState()
                     navigateToBack()
+                }
             }
         }
     }
@@ -98,7 +103,9 @@ fun RegisterScreen(
                 .padding(padding),
         ) {
             Column(
-                modifier = Modifier.matchParentSize().verticalScroll(scrollState)
+                modifier = Modifier
+                    .matchParentSize()
+                    .verticalScroll(scrollState)
             ) {
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/screen/RegisterScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/screen/RegisterScreen.kt
@@ -1,4 +1,4 @@
-package com.example.kuitandroidapiexample.register.screen
+package com.example.kuitandroidapiexample.ui.register.screen
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,10 +31,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.kuitandroidapiexample.home.viewmodel.AnimalViewModel
-import com.example.kuitandroidapiexample.model.AnimalType
-import com.example.kuitandroidapiexample.register.componet.FindUTextField
-import com.example.kuitandroidapiexample.register.componet.TypeSelectContent
+import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
+import com.example.kuitandroidapiexample.ui.model.AnimalType
+import com.example.kuitandroidapiexample.ui.register.componet.FindUTextField
+import com.example.kuitandroidapiexample.ui.register.componet.TypeSelectContent
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.colors
 import com.example.kuitandroidapiexample.ui.theme.FindUTheme.typography
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/register/viewmodel/AnimalRegisterViewModel.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/register/viewmodel/AnimalRegisterViewModel.kt
@@ -1,0 +1,69 @@
+package com.example.kuitandroidapiexample.ui.register.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.kuitandroidapiexample.data.dto.request.RequestAddAnimalDto
+import com.example.kuitandroidapiexample.data.repository.AnimalRepository
+import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModel
+import com.example.kuitandroidapiexample.ui.model.AnimalType
+import com.example.kuitandroidapiexample.ui.register.addstate.AnimalRegisterAddState
+import com.example.kuitandroidapiexample.ui.register.model.AddAnimalStateType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class AnimalRegisterViewModel(
+    private val animalRepository: AnimalRepository
+) : ViewModel() {
+
+    private val _addState = MutableStateFlow(AnimalRegisterAddState())
+    val addState = _addState.asStateFlow()
+
+    fun postAddAnimal(request: RequestAddAnimalDto) {
+        viewModelScope.launch {
+            animalRepository.postAddAnimal(request).fold(
+                onSuccess = {
+                    Log.d("postAddAnimal", "등록 성공")
+                    _addState.update { it.copy(addState = AddAnimalStateType.ADDSUCCESS) }
+                },
+                onFailure = { error ->
+                    Log.e("postAddAnimal", error.message ?: "Unknown error")
+                    _addState.update { it.copy(addState = AddAnimalStateType.ADDFAILURE) }
+                }
+            )
+        }
+    }
+
+    fun addAnimal(
+        url: String,
+        name: String,
+        state: AnimalType,
+        breed: String,
+        address: String
+    ) {
+        val request = RequestAddAnimalDto(
+            id = 1,
+            url = url,
+            name = name,
+            state = state,
+            breed = breed,
+            address = address
+        )
+        postAddAnimal(request)
+    }
+
+    fun resetAddState() {
+        _addState.update { it.copy(addState = AddAnimalStateType.PENDING) }
+    }
+
+}
+
+class AnimalRegisterViewModelFactory(
+    private val animalRepository: AnimalRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AnimalRegisterViewModel(animalRepository) as T
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/DataStoreManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/DataStoreManager.kt
@@ -1,0 +1,35 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.example.kuitandroidapiexample.ui.navigation.Route
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "my_datastore")
+
+object DataStoreManager {
+    private val SAMPLE_KEY = stringPreferencesKey("sample_key")
+
+    suspend fun saveValue(context: Context, value: String) {
+        context.dataStore.edit { prefs ->
+            prefs[SAMPLE_KEY] = value
+        }
+    }
+
+    fun getValue(context: Context): Flow<String?> {
+        return context.dataStore.data.map { prefs ->
+            prefs[SAMPLE_KEY]
+        }
+    }
+
+    suspend fun deleteValue(context: Context) {
+        context.dataStore.edit { prefs ->
+            prefs.remove(SAMPLE_KEY)
+        }
+    }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
@@ -1,0 +1,23 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import androidx.core.content.edit
+
+object SharedPreferenceManager {
+    fun saveValue(context: Context, key: String, value: String){
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit {
+            putString(key, value)
+        }
+    }
+    fun getValue(context: Context, key: String): String? {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        return prefs.getString(key, null)
+    }
+    fun deleteValue(context: Context, key: String){
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit {
+            remove(key)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.1"
+agp = "8.9.2"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -13,6 +13,7 @@ okhttp = "4.11.0"
 retrofit = "2.9.0"
 retrofitKotlinSerializationConverter = "1.0.0"
 kotlinxSerializationJson = "1.6.3"
+datastorePreferences = "1.2.0-alpha02"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,6 +37,7 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlin-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinSerializationConverter" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 미션
- [x]  실습 내용 구현해오기
- [x]  실습에서 작성한 PreferencesScreen에 기존의 SharedPreferencesManager 대신 DataStoreManager를 사용한 코드로 변경해오기 (두 경우 모두 시연할 수 있도록 기존의 코드는 주석처리해두기)

---

## 구현에 대한 설명
- PreferencesScreen에 SharedPreferences와 DataStore을 이용해서 데이터 저장, 조회, 삭제 기능 구현

---

## 스크린샷 & 실행영상
<img width="401" alt="스크린샷 2025-05-23 오후 1 22 32" src="https://github.com/user-attachments/assets/21e83c52-090a-44ea-a91f-a398ba88515e" />

---