### PR TITLE
8주차 미션 / 1조 조현승

### DIFF
--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.kuitandroidapiexample.ui.home.screen
 
+import android.R.attr.onClick
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,6 +17,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -41,6 +43,7 @@ fun HomeScreen(
     padding: PaddingValues,
     navigateToRegister: () -> Unit = {},
     navigateToDetail: (Int) -> Unit = {},
+    navigateToPref: () -> Unit = {},
     viewModel: AnimalViewModel = viewModel()
 ) {
     val lazyState = rememberLazyListState()
@@ -99,6 +102,24 @@ fun HomeScreen(
                     .size(36.dp),
                 imageVector = Icons.Filled.Add,
                 contentDescription = "등록하기 버튼",
+                tint = colors.white
+            )
+        }
+
+        IconButton(
+            modifier = Modifier
+                .padding(start = 17.dp, bottom = 20.dp)
+                .size(56.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(colors.orange)
+                .align(Alignment.BottomStart),
+            onClick = navigateToPref
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(36.dp),
+                imageVector = Icons.Filled.Build,
+                contentDescription = "pref 버튼",
                 tint = colors.white
             )
         }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/PreferencesScreen.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/home/screen/PreferencesScreen.kt
@@ -1,0 +1,98 @@
+package com.example.kuitandroidapiexample.ui.home.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.preferences.preferencesDataStore
+import com.example.kuitandroidapiexample.util.DataStoreManager
+import com.example.kuitandroidapiexample.util.SharedPreferenceManager
+import kotlinx.coroutines.launch
+
+@Composable
+fun PreferencesScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    var input by remember { mutableStateOf("") }
+    var result by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        TextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("input value") }
+        )
+
+        Button(
+            onClick = {
+//                SharedPreferenceManager.saveValue(
+//                    context = context,
+//                    key = "sample key",
+//                    value = input
+//                )
+                coroutineScope.launch {
+                    DataStoreManager.saveValue(
+                        context = context,
+                        key = "sample_data_key",
+                        value = input
+                    )
+                }
+            }
+        ) {
+            Text("pref 저장")
+        }
+        Button(
+            onClick = {
+//                SharedPreferenceManager.deleteValue(context = context, key = "sample key")
+                coroutineScope.launch {
+                    DataStoreManager.deleteValue(
+                        context = context,
+                        key = "sample_data_key"
+                    )
+                }
+            }
+        ) {
+            Text("pref 삭제")
+        }
+        Button(
+            onClick = {
+//                result = SharedPreferenceManager.getValue(context = context, key = "sample key")?:"없음"
+                coroutineScope.launch {
+                    result = DataStoreManager.getValue(
+                        context = context,
+                        key = "sample_data_key"
+                    )?:"없음"
+                }
+            }
+        ) {
+            Text("pref 조회")
+        }
+
+        Text("결과:$result")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreferencesScreenPreview() {
+    PreferencesScreen()
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/MainNavHost.kt
@@ -3,6 +3,7 @@ package com.example.kuitandroidapiexample.ui.navigation
 import android.app.Application
 import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +20,7 @@ import com.example.kuitandroidapiexample.ui.detail.screen.DetailScreen
 import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModel
 import com.example.kuitandroidapiexample.ui.detail.viewmodel.AnimalDetailViewModelFactory
 import com.example.kuitandroidapiexample.ui.home.screen.HomeScreen
+import com.example.kuitandroidapiexample.ui.home.screen.PreferencesScreen
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModel
 import com.example.kuitandroidapiexample.ui.home.viewmodel.AnimalViewModelFactory
 import com.example.kuitandroidapiexample.ui.register.screen.RegisterScreen
@@ -46,10 +48,10 @@ fun MainNavHost(
     LaunchedEffect(Unit) {
         scope.launch {
             detailViewModel.uiState.collect {
-                if(it.isDelete) {
+                if (it.isDelete) {
                     Log.d("s", "s")
-                }else {
-                    Log.d("it.toString()" ,it.toString())
+                } else {
+                    Log.d("it.toString()", it.toString())
                 }
             }
         }
@@ -69,6 +71,7 @@ fun MainNavHost(
 
                     navController.navigate(Route.Detail(index))
                 },
+                navigateToPref = { navController.navigate(Route.Preference) },
                 viewModel = viewModel
             )
         }
@@ -87,6 +90,9 @@ fun MainNavHost(
                 navigateToBack = { navController.navigateUp() },
                 viewModel = detailViewModel
             )
+        }
+        composable<Route.Preference> {
+            PreferencesScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/ui/navigation/Route.kt
@@ -11,4 +11,7 @@ sealed interface Route {
 
     @Serializable
     data class Detail(val index: Int) : Route
+
+    @Serializable
+    data object Preference : Route
 }

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/DataStoreManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/DataStoreManager.kt
@@ -1,0 +1,41 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.preferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "my_prefs")
+
+object DataStoreManager {
+    //DataStore 인스턴스 정의
+
+    //키 값 정의
+    val SAMPLE_KEY = stringPreferencesKey("sample_key")
+
+    suspend fun saveValue(context: Context, key: String, value: String) {
+        val dataStoreKey = stringPreferencesKey(key)
+        context.dataStore.edit { preferences ->
+            preferences[dataStoreKey] = value
+        }
+    }
+
+    suspend fun getValue(context: Context, key: String): String? {
+        val dataStoreKey = stringPreferencesKey(key)
+        return context.dataStore.data.map { preferences ->
+            preferences[dataStoreKey]
+        }.first()
+    }
+
+    suspend fun deleteValue(context: Context, key: String) {
+        val dataStoreKey = stringPreferencesKey(key)
+        context.dataStore.edit { preferences ->
+            preferences.remove(dataStoreKey)
+        }
+    }
+}

--- a/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/example/kuitandroidapiexample/util/SharedPreferenceManager.kt
@@ -1,0 +1,23 @@
+package com.example.kuitandroidapiexample.util
+
+import android.content.Context
+import androidx.core.content.edit
+
+object SharedPreferenceManager {
+    fun saveValue(context: Context, key: String, value: String) {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit {
+            putString(key, value)
+        }
+    }
+
+    fun getValue(context: Context, key: String): String? {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        return prefs.getString(key, null)
+    }
+
+    fun deleteValue(context: Context, key: String) {
+        val prefs = context.getSharedPreferences("my_prefs", Context.MODE_PRIVATE)
+        prefs.edit { remove(key) }
+    }
+}


### PR DESCRIPTION
## 📝 미션
- [x] 실습 내용 구현해오기
- [x] 실습에서 작성한 PreferencesScreen에 기존의 SharedPreferencesManager 대신 DataStoreManager를 사용한 코드로 변경해오기 (두 경우 모두 시연할 수 있도록 기존의 코드는 주석처리해두기)

## 🙋 구현에 대한 설명
PreferenceScreen에 SharedPreference 방식과 DataStore 방식 2가지를 이용하여서 로컬 데이터를 저장하고 삭제하고 조회할 수 있는 기능을 구현하였습니다.

## 📷 스크린샷 & 실행영상

https://github.com/user-attachments/assets/4468e4de-dd4e-45f9-9339-f6d7b08d59bf


## 🎸 기타
